### PR TITLE
feat(Validator): allow external validators

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ability-attributes",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A base package for the accessibility attributes schema runtime",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "ability-attributes-js-constraints": "^0.0.8"
+    "ability-attributes-js-constraints": "^0.0.9"
   },
   "devDependencies": {
     "rimraf": "^3.0.0",

--- a/base/src/DevEnv.ts
+++ b/base/src/DevEnv.ts
@@ -50,7 +50,8 @@ export function setup(settings?: DevEnvSettings): void {
             w.__abilityAttributesDev.jsConstraints,
             enforceClasses,
             assumeClass,
-            ignoreUnknownClasses
+            ignoreUnknownClasses,
+            settings?.externalValidators || []
         );
 
         Object.keys(Constraints).forEach(name => {

--- a/base/src/DevEnvTypes.ts
+++ b/base/src/DevEnvTypes.ts
@@ -12,6 +12,7 @@ export const ATTRIBUTE_NAME_CLASS = 'data-aa-class';
 export const ATTRIBUTE_NAME_ERROR_ID = 'data-aa-error-id';
 export const ATTRIBUTE_NAME_ERROR_MESSAGE = 'data-aa-error-message';
 export const ATTRIBUTE_NAME_PROPS = 'data-aa-props';
+export const ERROR_CONTAINER_SELECTOR = '.aa-error-container';
 
 export abstract class AbilityAttributesError extends Error {
     abstract readonly code: number;
@@ -59,4 +60,13 @@ export interface DevEnvSettings {
     enforceClasses?: boolean;
     ignoreUnknownClasses?: boolean;
     window?: Window;
+    externalValidators?: ExternalValidator[];
+}
+
+export interface AbilityAttributesExtenralError extends AbilityAttributesError {
+    element: HTMLElement;
+}
+
+export interface ExternalValidator {
+    validate: (elements: HTMLElement[], currentDocument: Document) => Promise<AbilityAttributesExtenralError[]>;
 }

--- a/base/src/ErrorReporter.ts
+++ b/base/src/ErrorReporter.ts
@@ -151,6 +151,8 @@ export class ErrorReporter extends ErrorReporterBase {
             this._container.style.display = 'none';
             this._expanded.style.display = 'none';
 
+            this._container.setAttribute('role', 'complementary');
+
             this._container.appendChild(this._expanded);
             this._container.appendChild(this._toggle);
 
@@ -228,7 +230,7 @@ export class ErrorReporter extends ErrorReporterBase {
             }
         });
 
-        this._expanded!.style.display = null;
+        this._expanded!.style.display = '';
         this._container!.style.display = 'flex';
     }
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ability-attributes-demo",
   "private": true,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A demo React project for the accessibility attributes schema",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "ability-attributes-generator": "^0.0.8",
+    "ability-attributes-generator": "^0.0.9",
     "awesome-typescript-loader": "^5.2.1",
     "rimraf": "^3.0.0",
     "source-map-loader": "^0.2.4",
@@ -31,7 +31,8 @@
   "dependencies": {
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
-    "ability-attributes": "^0.0.8",
+    "ability-attributes": "^0.0.9",
+    "axe-core": "^4.3.3",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   }

--- a/generator/package.json
+++ b/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ability-attributes-generator",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "An accessibility attributes schema code generator",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",
@@ -28,7 +28,7 @@
   },
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "ability-attributes": "^0.0.8",
+    "ability-attributes": "^0.0.9",
     "ajv": "^6.10.2",
     "commander": "^2.20.0"
   }

--- a/js-constraints/package.json
+++ b/js-constraints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ability-attributes-js-constraints",
-  "version": "0.0.8",
+  "version": "0.9",
   "description": "A set of JavaScript constraints for the accessibility attributes schema runtime",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,6 @@
         "generator",
         "js-constraints"
     ],
-    "version": "0.0.8",
+    "version": "0.0.9",
     "npmClient": "npm"
 }


### PR DESCRIPTION
Allow external validators, for example axe-core to report accessibility issues in the Error container.
Prevent re-validation when mutation happens based on a change in the error container